### PR TITLE
Add template submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Pytorch-Lightning"]
-	path = Pytorch-Lightning
+	path = python/Pytorch-Lightning
 	url = https://github.com/st7ma784/MLSlurmTemplate.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Pytorch-Lightning"]
+	path = Pytorch-Lightning
+	url = https://github.com/st7ma784/MLSlurmTemplate.git


### PR DESCRIPTION
Pull request for adding Pytorch lightning slurm template. 

In the pytorch-lightning folder are : 

- Sample dataloaders for huggingface. 
- Sample training scripts for PTL - that automatically accelerate on available hardware
- example logging to WandB
- Scripts to launch locally, slurm (HEC and Bede) as well as azure
